### PR TITLE
Add .archived and .unarchived scopes by default.

### DIFF
--- a/archivable.gemspec
+++ b/archivable.gemspec
@@ -19,10 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'activerecord'
   spec.add_dependency 'meta_magic'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'actionpack'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/archivable/model.rb
+++ b/lib/archivable/model.rb
@@ -1,8 +1,14 @@
 require 'active_support/concern'
+require 'active_record'
 
 module Archivable
   module Model
     extend ActiveSupport::Concern
+
+    included do
+      scope :archived, -> { where(archived: true) }
+      scope :unarchived, -> { where(archived: false) }
+    end
 
     def archived?
       archived

--- a/spec/archivable_model_spec.rb
+++ b/spec/archivable_model_spec.rb
@@ -38,4 +38,26 @@ describe Archivable::Model do
       subject.archive!
     end
   end
+
+  describe '.archived' do
+    let!(:archived_fake) { Fake.create(archived: true) }
+    let!(:unarchived_fake) { Fake.create(archived: false) }
+    it 'returns the archived object' do
+      expect(Fake.archived).to include(archived_fake)
+    end
+    it 'does not return the unarchievd object' do
+      expect(Fake.archived).to_not include(unarchived_fake)
+    end
+  end
+
+  describe '.unarchived' do
+    let!(:archived_fake) { Fake.create(archived: true) }
+    let!(:unarchived_fake) { Fake.create(archived: false) }
+    it 'does not return the archived object' do
+      expect(Fake.unarchived).to_not include(archived_fake)
+    end
+    it 'returns the unarchievd object' do
+      expect(Fake.unarchived).to include(unarchived_fake)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,16 +3,23 @@ require 'bundler/setup'
 require 'rspec'
 
 require 'action_controller'
+require 'active_record'
 
 require 'archivable'
 
-class Fake
-  include Archivable::Model
-  attr_accessor :archived
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
+                                        database: ':memory:')
 
-  def initialize(opts = {})
-    self.archived = opts[:archived] || false
-  end
+ActiveRecord::Schema.define do
+ self.verbose = false
+
+   create_table :fakes, cascade: true do |t|
+     t.boolean :archived
+   end
+end
+
+class Fake < ActiveRecord::Base
+  include Archivable::Model
 
   def toggle(dont_care)
     self.archived = archived ? false : true
@@ -20,10 +27,6 @@ class Fake
 
   def archived?
     !!archived
-  end
-
-  def save(opts = {})
-    true
   end
 end
 


### PR DESCRIPTION
As the title says. Addresses #7.

This adds:
- A base dependency: [ActiveRecord](https://github.com/rails/rails/tree/master/activerecord)
- A development dependency: [SQLite3](https://github.com/sparklemotion/sqlite3-ruby)
- The `.archived` and `.unarchived` scopes, with tests to guarantee.
