### PR TITLE
Migration should be edited to set the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ First, you need to add the `archived` column to your model (which we we call `Us
 $ rails g migration add_archived_to_users archived:boolean
 $ rake db:migrate
 ```
+NOTE: remember to edit the migration and set `:archived` column to default to `false` in order to simplify querying for non-archived models.
 
 ### Application Routes
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ $ rake db:migrate
 ```
 NOTE: remember to edit the migration and set `:archived` column to default to `false` in order to simplify querying for non-archived models.
 
+```
+  add_column :users, :archived, :boolean, default: false
+```
+
 ### Application Routes
 
 In your routes file (`config/routes.rb`):


### PR DESCRIPTION
NOTE: remember to edit the migration and set `:archived` column to default to `false` in order to simplify querying for non-archived models.